### PR TITLE
Fix RepoKeeper reusable workflow token secret names

### DIFF
--- a/.github/workflows/repokeeper-agent.yml
+++ b/.github/workflows/repokeeper-agent.yml
@@ -20,7 +20,7 @@ on:
       deepseek_api_key:
         required: true
         description: "DeepSeek (or OpenAI-compatible) API key"
-      github_token:
+      repo_token:
         required: true
         description: "GitHub token with contents:write, issues:write, pull-requests:write"
       llm_base_url:
@@ -50,7 +50,7 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
           DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
-          REPOKEEPER_GITHUB_TOKEN: ${{ secrets.github_token }}
+          REPOKEEPER_GITHUB_TOKEN: ${{ secrets.repo_token }}
           GITHUB_REPOSITORY: ${{ inputs.repo }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           LLM_BASE_URL: ${{ secrets.llm_base_url || 'https://api.deepseek.com' }}

--- a/.github/workflows/repokeeper-patrol.yml
+++ b/.github/workflows/repokeeper-patrol.yml
@@ -21,7 +21,7 @@ on:
       deepseek_api_key:
         required: true
         description: "DeepSeek (or OpenAI-compatible) API key"
-      github_token:
+      repo_token:
         required: true
         description: "GitHub token with issues:read, pull-requests:write, contents:write, actions:read"
 
@@ -46,7 +46,7 @@ jobs:
       - name: Run Daily Patrol
         env:
           DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.repo_token }}
           GITHUB_REPOSITORY: ${{ inputs.repo }}
         run: repokeeper patrol --repo "$GITHUB_REPOSITORY" --summary | tee patrol-summary.md "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/repokeeper-radar.yml
+++ b/.github/workflows/repokeeper-radar.yml
@@ -16,7 +16,7 @@ on:
       deepseek_api_key:
         required: true
         description: "DeepSeek (or OpenAI-compatible) API key for LLM classification"
-      github_token:
+      repo_token:
         required: true
         description: "GitHub token with issues:write, discussions:read, contents:read"
       smtp_host:
@@ -55,7 +55,7 @@ jobs:
       - name: Run Community Radar
         env:
           DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.repo_token }}
           GITHUB_REPOSITORY: ${{ inputs.repo }}
           RKP_SMTP_HOST: ${{ secrets.smtp_host || '' }}
           RKP_SMTP_PORT: ${{ secrets.smtp_port || '587' }}

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ jobs:
       python_version: "3.10"         # default: 3.10
     secrets:
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
-      github_token: ${{ secrets.REPOKEEPER_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      repo_token: ${{ secrets.REPOKEEPER_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
       llm_base_url: ${{ secrets.LLM_BASE_URL }}  # optional, defaults to https://api.deepseek.com
 ```
 
@@ -143,7 +143,7 @@ jobs:
       python_version: "3.10"         # default: 3.10
     secrets:
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      repo_token: ${{ secrets.GITHUB_TOKEN }}
       smtp_host: ${{ secrets.RKP_SMTP_HOST }}           # optional
       smtp_port: ${{ secrets.RKP_SMTP_PORT }}           # optional
       smtp_user: ${{ secrets.RKP_SMTP_USER }}           # optional
@@ -165,7 +165,7 @@ jobs:
       repo_path: "."                 # default: .
     secrets:
       deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      repo_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Community Health Files


### PR DESCRIPTION
### Motivation
- The `workflow_call` inputs used the secret name `github_token`, which conflicts with GitHub's reserved `github_token` name and caused workflow parsing errors.
- Reusable workflows need a non-reserved secret name to allow callers to pass a repository token safely.

### Description
- Rename the `workflow_call` secret from `github_token` to `repo_token` in `repokeeper-agent.yml`, `repokeeper-patrol.yml`, and `repokeeper-radar.yml`.
- Update runtime environment variables to read the token from `secrets.repo_token` (for example `REPOKEEPER_GITHUB_TOKEN: ${{ secrets.repo_token }}` and `GITHUB_TOKEN: ${{ secrets.repo_token }}`).
- Update README examples to show callers passing `repo_token` instead of `github_token` for the agent, radar, and patrol reusable workflows.

### Testing
- `ruby -e 'require "yaml"; Dir[".github/workflows/repokeeper-*.yml"].sort.each { |p| YAML.load_file(p); puts "parsed #{p}" }'` — parsed all modified workflows successfully.
- `rg -n "github_token|secrets\.github_token" .github/workflows/repokeeper-*.yml README.md || true` — no remaining occurrences of the reserved `github_token` secret in the updated files.
- `git diff --check` — whitespace/format check passed with no problems.
- Attempted YAML parse with Python (`PyYAML`) failed due to `PyYAML` not being installed in the environment, so Ruby was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1e4e282c8331ba764fc5888265aa)