### PR TITLE
chore: migrate release-drafter config to new `when` syntax

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,73 +5,92 @@ tag-template: 'v$RESOLVED_VERSION'
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
   - title: 💥 Breaking changes
-    labels:
-      - breaking
+    when:
+      labels:
+        - breaking
   - title: 🚨 Removed
-    labels:
-      - removed
+    when:
+      labels:
+        - removed
   - title: 🎉 Major features and improvements
-    labels:
-      - major-enhancement
-      - major-rfe
+    when:
+      labels:
+        - major-enhancement
+        - major-rfe
   - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
+    when:
+      labels:
+        - major-bug
   - title: ⚠️ Deprecated
-    labels:
-      - deprecated
+    when:
+      labels:
+        - deprecated
   - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
+    when:
+      labels:
+        - enhancement
+        - feature
   - title: 🐛 Bug fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
+    when:
+      labels:
+        - bug
+        - fix
+        - bugfix
+        - regression
   - title: 🌐 Localization and translation
-    labels:
-      - localization
+    when:
+      labels:
+        - localization
   - title: 👷 Changes for developers
-    labels:
-      - developer
+    when:
+      labels:
+        - developer
   - title: 📝 Documentation updates
-    labels:
-      - documentation
+    when:
+      labels:
+        - documentation
   - title: 👻 Maintenance
-    labels:
-      - chore
-      - internal
-      - maintenance
+    when:
+      labels:
+        - chore
+        - internal
+        - maintenance
   - title: 🚦 Tests
-    labels:
-      - test
-      - tests
+    when:
+      labels:
+        - test
+        - tests
   - title: ✍ Other changes
-  # Default label used by Dependabot
   - title: 📦 Dependency updates
-    labels:
-      - dependencies
+    when:
+      labels:
+        - dependencies
     collapse-after: 15
-exclude-labels:
-  - no-changelog
-  - skip-changelog
-  - invalid
+  - type: pre-exclude
+    when:
+      labels:
+        - no-changelog
+        - skip-changelog
+        - invalid
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - major
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - minor
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels:
+        - patch
+  - type: version-resolver
+    semver-increment: patch
 
 change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
-# https://github.com/release-drafter/release-drafter?tab=readme-ov-file#version-resolver
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
 
 template: |
   <!-- Optional: add a release summary here -->


### PR DESCRIPTION
## Summary

Migrate the release-drafter configuration to the new `when`-based syntax to eliminate deprecation warnings.

## Changes

The deprecated `labels` field under each category has been moved inside a `when` condition (per [release-drafter PR #1558](https://github.com/release-drafter/release-drafter/pull/1558)):

**Old:**
```yaml
categories:
  - title: 💥 Breaking changes
    labels:
      - breaking
```

**New:**
```yaml
categories:
  - title: 💥 Breaking changes
    when:
      labels:
        - breaking
```

Additionally:
- `exclude-labels` → converted to a category with `type: pre-exclude`
- `version-resolver` → converted to categories with `type: version-resolver` and `semver-increment`
- The `default: patch` is now represented as a `version-resolver` entry without a `when` condition
- Removed outdated comments

## Why

These warnings appear in every run of the release-drafter workflow (see gitoxide repo's workflow logs). The old `labels` field will be removed in a future release.