### PR TITLE
chore: group github actions version updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+    groups:
+      github-action:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Closes #32 — configure Dependabot to group GitHub Actions version updates into a **single pull request** instead of one PR per action (e.g. #31, #25).

## Changes

`.github/dependabot.yml` — added a `groups` block to the `github-actions` update:

```yaml
groups:
  github-action:
    patterns:
      - "*"
```

All GitHub Actions dependency bumps will now be batched into one PR (e.g. "Bump the github-action group with N updates"), matching the setup already used in [shenxianpeng/gitstats](https://github.com/shenxianpeng/gitstats/blob/main/.github/dependabot.yml).

## Validation

- YAML parses successfully (`yaml.safe_load`)
- Existing pre-commit `check-yaml` hook passes

Closes #32
