### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,11 +43,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -74,6 +74,6 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,8 +7,8 @@ jobs:
   mkdocs-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
       - name: Install dependencies
@@ -18,7 +18,7 @@ jobs:
         run: mkdocs build
       - name: Upload docs build as artifact
         if: github.ref != 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}_docs
           path: ${{ github.workspace }}/site

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Automatically label pull requests based on the release-drafter config
-      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
   run-pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         id: python-setup
         with:
           python-version: '3.x'
@@ -22,7 +22,7 @@ jobs:
         if: inputs.commands
         run: ${{ inputs.commands }}
       - name: Cache pre-commit environments
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: '~/.cache/pre-commit'
           key: pre-commit-${{ steps.python-setup.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.x'
 

--- a/.github/workflows/repokeeper-agent.yml
+++ b/.github/workflows/repokeeper-agent.yml
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Run RepoKeeper Agent
-        uses: shenxianpeng/repokeeper/agent@v1
+        uses: shenxianpeng/repokeeper/agent@df2cc86986f0cc3d29eb978813cffcaa22b4438b # v1.4.0
         with:
           repo: ${{ inputs.repo }}
           issue: ${{ inputs.issue_number }}

--- a/.github/workflows/repokeeper-labeler.yml
+++ b/.github/workflows/repokeeper-labeler.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Run RepoKeeper Labeler
-        uses: shenxianpeng/repokeeper/labeler@v1
+        uses: shenxianpeng/repokeeper/labeler@df2cc86986f0cc3d29eb978813cffcaa22b4438b # v1.4.0
         with:
           repo: ${{ inputs.repo }}
           issue: ${{ inputs.issue }}

--- a/.github/workflows/repokeeper-patrol.yml
+++ b/.github/workflows/repokeeper-patrol.yml
@@ -25,7 +25,7 @@ jobs:
       actions: read
     steps:
       - name: Run Daily Patrol
-        uses: shenxianpeng/repokeeper/patrol@v1
+        uses: shenxianpeng/repokeeper/patrol@df2cc86986f0cc3d29eb978813cffcaa22b4438b # v1.4.0
         with:
           repo: ${{ inputs.repo }}
           llm_api_key: ${{ secrets.deepseek_api_key }}

--- a/.github/workflows/repokeeper-radar.yml
+++ b/.github/workflows/repokeeper-radar.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - name: Run Community Radar
-        uses: shenxianpeng/repokeeper/radar@v1
+        uses: shenxianpeng/repokeeper/radar@df2cc86986f0cc3d29eb978813cffcaa22b4438b # v1.4.0
         with:
           repo: ${{ inputs.repo }}
           llm_api_key: ${{ secrets.deepseek_api_key }}

--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -25,7 +25,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Run Snyk to check Docker image for vulnerabilities
       continue-on-error: true
       uses: snyk/actions/docker@master
@@ -39,6 +39,6 @@ jobs:
         args: --severity-threshold=${{ inputs.severity-threshold }} --file=${{ inputs.dockerfile }}
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         sarif_file: snyk.sarif

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -13,8 +13,8 @@ jobs:
   sphinx-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
       - name: Install dependencies
@@ -24,7 +24,7 @@ jobs:
         run: sphinx-build docs ${{ inputs.path-to-doc }}
 
       - name: Upload docs build as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}_docs
           path: ${{ github.workspace }}/${{ inputs.path-to-doc }}
@@ -32,7 +32,7 @@ jobs:
       - name: Upload to github pages
         # only publish doc changes from main branch
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./${{ inputs.path-to-doc }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
             stale-issue-message: >-
                 This issue has been automatically marked as stale because


### PR DESCRIPTION
## Summary

Pin all GitHub Actions in workflows to **full-length commit SHAs**, with the concrete release version in a trailing comment — so a version tag never hides which exact commit is running.

```yaml
# before:  - uses: actions/setup-python@v7
# after:   - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
```

Each SHA was verified against the tag it replaces (`git ls-remote` on the tag ref, dereferencing annotated tags).

## This supersedes dependabot PR #34

The three updates from #34 are included here in SHA form:

| Action | Update | Pinned SHA | Version |
|--------|--------|-----------|---------|
| actions/setup-python | v6 → v7 | `5fda3b95…` | # v7.0.0 |
| actions/stale | v10 → v11 | `4391f3da…` | # v11.0.0 |
| release-drafter autolabeler | v7.5.1 → v7.7.0 | `34d80673…` | # v7.7.0 |

Please close #34 after merging this.

## All other actions pinned too (same rationale)

| Action | Was | SHA | Version |
|--------|-----|-----|---------|
| actions/checkout (×5) | @v7 | `3d3c42e5…` | # v7.0.1 |
| actions/upload-artifact (×2) | @v7 | `043fb46d…` | # v7.0.1 |
| actions/cache | @v6 | `55cc8345…` | # v6.1.0 |
| github/codeql-action (×4) | @v4 | `f205ea1c…` | # v4.37.4 |
| peaceiris/actions-gh-pages | @v4 | `84c30a85…` | # v4.1.0 |
| shenxianpeng/repokeeper (×4) | @v1 | `df2cc869…` | # v1.4.0 |

## Notes

- `snyk/actions/docker@master` kept as-is — it has no version tag
- `release-drafter/release-drafter@34d80673… # v7.7.0` was already pinned
- 24 replacements across 12 workflow files; all YAML files validated
